### PR TITLE
商品購入機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,3 +98,9 @@ gem 'active_hash'
 # 画像アップロード機能
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
+# 20230923下記を追記
+# 決済処理
+gem 'payjp'
+# 20230924下記を追記
+# クライアントサイドで環境変数を読み込めるように
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -113,6 +115,14 @@ GEM
       romaji
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -141,10 +151,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.7)
       date
@@ -155,6 +169,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
@@ -165,6 +180,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -215,9 +232,16 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.8)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.6)
     romaji (0.2.4)
       rake (>= 0.8.0)
@@ -278,6 +302,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -311,11 +338,13 @@ DEPENDENCIES
   factory_bot_rails
   faker
   gimei
+  gon
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  payjp
   pg
   pry-rails
   puma (~> 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
+  # deviseコントローラー時に下記privateメソッドを実行
   before_action :configure_permitted_parameters, if: :devise_controller?
 
 
@@ -11,6 +12,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # 新規登録時、emailとencrypted_password以外もストロングパラメーターとして許可
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birth_date])
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,7 +34,8 @@ class ItemsController < ApplicationController
 
   def edit
     # ログインしているユーザーと同一であればeditファイルが読み込まれる
-    if @item.user_id == current_user.id
+    # && @item.order.nil?で売却済みの場合は編集画面に遷移できずroot_pathに遷移する
+    if @item.user_id == current_user.id && @item.order.nil?
     else
       redirect_to root_path
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,5 @@
+class OrdersController < ApplicationController
+  def index
+  end
+
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,15 +2,11 @@ class OrdersController < ApplicationController
     before_action :authenticate_user!
     # 重複処理のまとめ
     before_action :set_item, only: [ :index, :create]
+    before_action :pkey_env, only: [ :index, :create]
 
   def index
-    # RailsからJavaScriptへ公開鍵を渡す記述
-    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+    pkey_env
     # Formオブジェクトのインスタンスを作成して、インスタンス変数に代入する
-    @order_address = OrderAddress.new
-  end
-
-  def new
     @order_address = OrderAddress.new
   end
 
@@ -23,8 +19,7 @@ class OrdersController < ApplicationController
       # 保存が成功した場合の処理を追加（例: 注文完了ページへのリダイレクトなど）
       redirect_to root_path
     else
-      # gonを使用するための記述
-      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      pkey_env
       # バリデーションエラーが発生した場合の処理を追加
       render :index, status: :unprocessable_entity
     end
@@ -50,7 +45,11 @@ class OrdersController < ApplicationController
   def set_item
     @item = Item.find(params[:item_id])
     redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
+  end
 
+  def pkey_env
+    # RailsからJavaScriptへ公開鍵を渡す記述
+    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -28,7 +28,7 @@ class OrdersController < ApplicationController
   private
 
   def order_params
-    params.require(:order_address).permit(:postal_code, :item_prefecture_id, :city, :addresses, :building, :phone_number).merge(user_id: current_user.id, item_id: @item.id)
+    params.require(:order_address).permit(:postal_code, :item_prefecture_id, :city, :addresses, :building, :phone_number).merge(user_id: current_user.id, item_id: @item.id, token: params[:token])
   end
 
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -49,6 +49,8 @@ class OrdersController < ApplicationController
 
   def set_item
     @item = Item.find(params[:item_id])
+    redirect_to root_path if current_user.id == @item.user_id || @item.order.present?
+
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,38 @@
 class OrdersController < ApplicationController
+
+    # 重複処理のまとめ
+    before_action :set_item, only: [ :index, :create]
+
   def index
+    # Formオブジェクトのインスタンスを作成して、インスタンス変数に代入する
+    @order_address = OrderAddress.new
+  end
+
+  def new
+  end
+
+  def create
+    @order_address = OrderAddress.new(order_params)
+
+    if @order_address.valid?
+      @order_address.save
+      # 保存が成功した場合の処理を追加（例: 注文完了ページへのリダイレクトなど）
+      redirect_to root_path
+    else
+      # バリデーションエラーが発生した場合の処理を追加（例: 注文フォームの再表示など）
+      render :index
+    end
+  end
+
+  private
+
+  def order_params
+    params.require(:order_address).permit(:postal_code, :item_prefecture_id, :city, :addresses, :building, :phone_number).merge(user_id: current_user.id, item_id: @item.id)
+  end
+
+
+  def set_item
+    @item = Item.find(params[:item_id])
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,6 +9,7 @@ class OrdersController < ApplicationController
   end
 
   def new
+    @order_address = OrderAddress.new
   end
 
   def create
@@ -20,7 +21,7 @@ class OrdersController < ApplicationController
       redirect_to root_path
     else
       # バリデーションエラーが発生した場合の処理を追加（例: 注文フォームの再表示など）
-      render :index
+      render :index, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -20,7 +20,7 @@ class OrdersController < ApplicationController
       # 保存が成功した場合の処理を追加（例: 注文完了ページへのリダイレクトなど）
       redirect_to root_path
     else
-      # バリデーションエラーが発生した場合の処理を追加（例: 注文フォームの再表示など）
+      # バリデーションエラーが発生した場合の処理を追加
       render :index, status: :unprocessable_entity
     end
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,9 +1,11 @@
 class OrdersController < ApplicationController
-
+    before_action :authenticate_user!
     # 重複処理のまとめ
     before_action :set_item, only: [ :index, :create]
 
   def index
+    # RailsからJavaScriptへ公開鍵を渡す記述
+    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
     # Formオブジェクトのインスタンスを作成して、インスタンス変数に代入する
     @order_address = OrderAddress.new
   end
@@ -16,10 +18,13 @@ class OrdersController < ApplicationController
     @order_address = OrderAddress.new(order_params)
 
     if @order_address.valid?
+      pay_item
       @order_address.save
       # 保存が成功した場合の処理を追加（例: 注文完了ページへのリダイレクトなど）
       redirect_to root_path
     else
+      # gonを使用するための記述
+      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
       # バリデーションエラーが発生した場合の処理を追加
       render :index, status: :unprocessable_entity
     end
@@ -29,6 +34,16 @@ class OrdersController < ApplicationController
 
   def order_params
     params.require(:order_address).permit(:postal_code, :item_prefecture_id, :city, :addresses, :building, :phone_number).merge(user_id: current_user.id, item_id: @item.id, token: params[:token])
+  end
+
+  def pay_item
+    # 決済処理を記述
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp::Charge.create(
+      amount: @item.item_price,  # 商品の値段
+      card: order_params[:token],    # カードトークン
+      currency: 'jpy'                 # 通貨の種類（日本円）
+    )
   end
 
 

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "item_price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,9 @@
+const pay = () => {
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    console.log("フォーム送信時にイベント発火")
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("turbo:load", pay);

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -15,8 +15,14 @@ const pay = () => {
       if (response.error) {
       } else {
         const token = response.id;
-        console.log(token)
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
       }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
     });
     e.preventDefault();
   });

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,5 +1,6 @@
 const pay = () => {
-  const payjp = Payjp('pk_test_338810afeb8c27dcf1e8118c')// PAY.JPテスト公開鍵
+  const publicKey = gon.public_key
+  const payjp = Payjp(publicKey) // PAY.JPテスト公開鍵
   const elements = payjp.elements();
   const numberElement = elements.create('cardNumber');
   const expiryElement = elements.create('cardExpiry');
@@ -29,3 +30,4 @@ const pay = () => {
 };
 
 window.addEventListener("turbo:load", pay);
+window.addEventListener("turbo:render", pay);

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,7 +1,23 @@
 const pay = () => {
+  const payjp = Payjp('pk_test_338810afeb8c27dcf1e8118c')// PAY.JPテスト公開鍵
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+
   const form = document.getElementById('charge-form')
   form.addEventListener("submit", (e) => {
-    console.log("フォーム送信時にイベント発火")
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        console.log(token)
+      }
+    });
     e.preventDefault();
   });
 };

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,8 @@ class Item < ApplicationRecord
 
   # usersテーブルとのアソシエーション
   belongs_to :user
+  # ordersテーブルとのアソシエーション
+  has_one :order
 
   # active_storageとのアソシエーション
   # items・active_storage_blobsテーブルを関連付け

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one    :address
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -5,14 +5,17 @@ class OrderAddress
 
   with_options presence: true do
     # orderモデルのバリデーション
-    validates :user_id # order_addressクラスにはアソシエーションを定義することはできないため、belongs_toによるバリデーションを行うことができないのでorder_addressクラスでuser_idに対してバリデーションを新たに設定。
+    validates :user_id # order_addressクラスにはアソシエーションを定義することはできない、belongs_toによるバリデーションを行うことができないのでorder_addressクラスでuser_idとitem_idに対してバリデーションを新たに設定。
     validates :item_id
     # addressesモデルのバリデーション
     validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)" }
     validates :item_prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
     validates :city
     validates :addresses
-    validates :phone_number, format: { with: /\A[0-9]{11}\z/, message: 'is invalid. Input only number' }
+    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'is invalid. Input only number' }
+    validates_length_of :phone_number, maximum: 11, message: 'is too long'
+    validates_length_of :phone_number, minimum: 10, message: 'is too short'
+
   end
 
   # フォームから送られてきた情報をテーブルに保存する処理

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,7 +1,7 @@
 class OrderAddress
   include ActiveModel::Model
   # ordesテーブルとaddressesテーブルに保存したいカラム名をすべて指定
-  attr_accessor :user_id, :item_id, :postal_code, :item_prefecture_id, :city, :addresses, :building, :phone_number
+  attr_accessor :user_id, :item_id, :postal_code, :item_prefecture_id, :city, :addresses, :building, :phone_number, :token
 
   with_options presence: true do
     # orderモデルのバリデーション
@@ -15,7 +15,7 @@ class OrderAddress
     validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'is invalid. Input only number' }
     validates_length_of :phone_number, maximum: 11, message: 'is too long'
     validates_length_of :phone_number, minimum: 10, message: 'is too short'
-
+    validates :token
   end
 
   # フォームから送られてきた情報をテーブルに保存する処理

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,26 @@
+class OrderAddress
+  include ActiveModel::Model
+  # ordesテーブルとaddressesテーブルに保存したいカラム名をすべて指定
+  attr_accessor :user_id, :item_id, :postal_code, :item_prefecture_id, :city, :addresses, :building, :phone_number
+
+  with_options presence: true do
+    # orderモデルのバリデーション
+    validates :user_id # order_addressクラスにはアソシエーションを定義することはできないため、belongs_toによるバリデーションを行うことができないのでorder_addressクラスでuser_idに対してバリデーションを新たに設定。
+    validates :item_id
+    # addressesモデルのバリデーション
+    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)" }
+    validates :item_prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+    validates :city
+    validates :addresses
+    validates :phone_number, format: { with: /\A[0-9]{11}\z/, message: 'is invalid. Input only number' }
+  end
+
+  # フォームから送られてきた情報をテーブルに保存する処理
+  def save
+    # 購入情報を保存し、変数orderに代入する
+    order = Order.create(user_id: user_id, item_id: item_id)
+    # 住所を保存する
+    # order_idには、変数orderのidと指定する
+    Address.create(postal_code: postal_code, prefecture: prefecture, city: city, house_number: house_number, building_name: building_name, order_id: order.id)
+  end
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -21,6 +21,6 @@ class OrderAddress
     order = Order.create(user_id: user_id, item_id: item_id)
     # 住所を保存する
     # order_idには、変数orderのidと指定する
-    Address.create(postal_code: postal_code, prefecture: prefecture, city: city, house_number: house_number, building_name: building_name, order_id: order.id)
+    Address.create(postal_code: postal_code, item_prefecture_id: item_prefecture_id, city: city, addresses: addresses, building: building, phone_number: phone_number, order_id: order.id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
 
   # itemsテーブルとのアソシエーション
   has_many :items
+  # ordersテーブルとのアソシエーション
+  has_many :orders
 
   #空の投稿を保存できないようにする
   with_options presence: true do

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,11 @@
           <div class='item-img-content'>
             <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 
-            <%# 商品が売れていればsold outを表示しましょう %>
+            <% if item.order != nil %>
               <div class='sold-out'>
                 <span>Sold Out!!</span>
               </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
+            <% end %>
 
           </div>
           <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
         <p class="or-text">or</p>
         <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%= link_to "購入画面に進む", item_orders_path(@item.id) ,class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image.variant(resize: '500x500'),class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.order != nil %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -24,11 +24,11 @@
     </div>
 
     <% if user_signed_in? %>
-      <%if current_user.id == @item.user_id %>
+      <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
-      <% else %>
+      <% elsif @item.order.nil? %>
         <%= link_to "購入画面に進む", item_orders_path(@item.id) ,class:"item-red-btn"%>
       <% end %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,127 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= "商品名" %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= '999,999,999' %></p>
+          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= "販売価格" %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="number-form" class="input-default"></div>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <div id="expiry-form" class="input-default"></div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="cvc-form" class="input-default"></div>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,4 +1,6 @@
 <%= render "shared/second-header"%>
+<%# ビューにgonの読み込み設定 %>
+<%= include_gon %>
 
 <div class='transaction-contents'>
   <div class='transaction-main'>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image.variant(resize: '500x500'), class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.item_name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.item_price %></p>
+          <p class='item-price-sub-text'><%= @item.item_shipping_fee_status.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,12 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.item_price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_address, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap', local: true do |f| %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -68,7 +68,7 @@
       </div>
     </div>
     <%# /カード情報の入力 %>
-    
+
     <%# 配送先の入力 %>
     <div class='shipping-address-form'>
       <h1 class='info-input-haedline'>
@@ -79,42 +79,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:item_prefecture_id, ItemPrefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :addresses, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -32,6 +32,9 @@
     <%# /支払額の表示 %>
 
     <%= form_with model: @order_address, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap', local: true do |f| %>
+
+    <%= render 'shared/error_messages', model: @order_address, object: f.object %>
+
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.active_job.queue_adapter = :inline
 end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "item_price", to: "item_price.js"
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get 'items/index'
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :items do
+    resources :orders, only: [:index, :create]
+  end
 end

--- a/db/migrate/20230920071413_create_orders.rb
+++ b/db/migrate/20230920071413_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230920071447_create_addresses.rb
+++ b/db/migrate/20230920071447_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :addresses do |t|
+      t.string     :postal_code,        null: false
+      t.integer    :item_prefecture_id, null: false
+      t.string     :city,               null: false
+      t.string     :addresses,          null: false
+      t.string     :building
+      t.string     :phone_number,       null: false
+      t.references :order,              null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_16_185349) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_20_071447) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_185349) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "addresses", charset: "utf8", force: :cascade do |t|
+    t.string "postal_code", null: false
+    t.integer "item_prefecture_id", null: false
+    t.string "city", null: false
+    t.string "addresses", null: false
+    t.string "building"
+    t.string "phone_number", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
   create_table "items", charset: "utf8", force: :cascade do |t|
     t.string "item_name", null: false
     t.text "item_info", null: false
@@ -52,6 +65,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_185349) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|
@@ -74,5 +96,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_185349) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     addresses { Faker::Address.street_address }
     building { Faker::Address.street_address }
     phone_number { Faker::Number.decimal_part(digits: 11) }
+    token { Faker::Internet.password(min_length: 20, max_length: 30) }
   end
 end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :order_address do
+    user_id { Faker::Number.non_zero_digit }
+    item_id { Faker::Number.non_zero_digit }
+    postal_code { Faker::Number.decimal_part(digits: 3) + '-' + Faker::Number.decimal_part(digits: 4) }
+    item_prefecture_id { Faker::Number.between(from: 2, to: 48) }
+    city { Faker::Address.city }
+    addresses { Faker::Address.street_address }
+    building { Faker::Address.street_address }
+    phone_number { Faker::Number.decimal_part(digits: 11) }
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :order_address do
-    user_id { Faker::Number.non_zero_digit }
-    item_id { Faker::Number.non_zero_digit }
     postal_code { Faker::Number.decimal_part(digits: 3) + '-' + Faker::Number.decimal_part(digits: 4) }
     item_prefecture_id { Faker::Number.between(from: 2, to: 48) }
     city { Faker::Address.city }

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe OrderAddress, type: :model do
           @order_address.phone_number = 12_345_678_910
           expect(@order_address).to be_valid
         end
+
+        it "tokenがあれば保存ができること" do
+          expect(@order_address).to be_valid
+        end
+
       end
 
       context '配送先情報の保存ができないとき' do
@@ -123,6 +128,12 @@ RSpec.describe OrderAddress, type: :model do
           @order_address.phone_number = '123 - 4567 - 8901'
           @order_address.valid?
           expect(@order_address.errors.full_messages).to include('Phone number is invalid. Input only number')
+        end
+
+        it "tokenが空では登録できないこと" do
+          @order_address.token = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Token can't be blank")
         end
       end
     end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe OrderAddress, type: :model do
   describe '配送先情報の保存' do
     before do
-      @order_address = FactoryBot.build(:order_address)
+      user = FactoryBot.create(:user)
+      item = FactoryBot.create(:item)
+      @order_address = FactoryBot.build(:order_address, user_id: user.id, item_id: item.id)
     end
 
       context '配送先情報の保存ができるとき' do

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  describe '配送先情報の保存' do
+    before do
+      @order_address = FactoryBot.build(:order_address)
+    end
+
+      context '配送先情報の保存ができるとき' do
+        it 'postal_code、item_prefecture_id、city、addresses、building、phone_numberの値が正しく入力されて入れいれば登録できる' do
+          expect(@order_address).to be_valid
+        end
+
+        it 'user_idが空でなければ保存できる' do
+          @order_address.user_id = 1
+          expect(@order_address).to be_valid
+        end
+
+        it 'item_idが空でなければ保存できる' do
+          @order_address.item_id = 1
+          expect(@order_address).to be_valid
+        end
+
+        it '郵便番号が「3桁＋ハイフン＋4桁」の組み合わせであれば保存できる' do
+          @order_address.postal_code = '123-4567'
+          expect(@order_address).to be_valid
+        end
+
+        it '都道府県が「---」以外かつ空でなければ保存できる' do
+          @order_address.item_prefecture_id = 2
+          expect(@order_address).to be_valid
+        end
+
+        it '市区町村が空でなければ保存できる' do
+          @order_address.city = '八王子市'
+          expect(@order_address).to be_valid
+        end
+
+        it '番地が空でなければ保存できる' do
+          @order_address.addresses = '１番地１２３'
+          expect(@order_address).to be_valid
+        end
+
+        it '建物名が空でも保存できる' do
+          @order_address.building = nil
+          expect(@order_address).to be_valid
+        end
+
+        it '電話番号が11桁以内かつハイフンなしであれば保存できる' do
+          @order_address.phone_number = 12_345_678_910
+          expect(@order_address).to be_valid
+        end
+      end
+
+      context '配送先情報の保存ができないとき' do
+        it 'user_idが空だと保存できない' do
+          @order_address.user_id = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("User can't be blank")
+        end
+
+        it 'item_idが空だと保存できない' do
+          @order_address.item_id = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Item can't be blank")
+        end
+
+        it '郵便番号が空だと保存できないこと' do
+          @order_address.postal_code = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Postal code can't be blank", 'Postal code is invalid. Include hyphen(-)')
+        end
+
+        it '郵便番号にハイフンがないと保存できないこと' do
+          @order_address.postal_code = 1_234_567
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
+        end
+
+        it '都道府県が「---」だと保存できないこと' do
+          @order_address.item_prefecture_id = 1
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Item prefecture can't be blank")
+        end
+
+        it '都道府県が空だと保存できないこと' do
+          @order_address.item_prefecture_id = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Item prefecture can't be blank")
+        end
+
+        it '市区町村が空だと保存できないこと' do
+          @order_address.city = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("City can't be blank")
+        end
+
+        it '番地が空だと保存できないこと' do
+          @order_address.addresses = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Addresses can't be blank")
+        end
+
+        it '電話番号が空だと保存できないこと' do
+          @order_address.phone_number = nil
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include("Phone number can't be blank")
+        end
+
+        it '電話番号が10桁以下であると保存できないこと' do
+          @order_address.phone_number = '123456789'
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include('Phone number is too short')
+        end
+
+        it '電話番号が12桁以上でないと保存できないこと' do
+          @order_address.phone_number = '123456789012'
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include('Phone number is too long')
+        end
+
+        it '電話番号にハイフンがあると保存できないこと' do
+          @order_address.phone_number = '123 - 4567 - 8901'
+          @order_address.valid?
+          expect(@order_address.errors.full_messages).to include('Phone number is invalid. Input only number')
+        end
+      end
+    end
+  end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
# What
商品購入機能の実装


# Why
商品購入画面で商品の購入をPAY.JPを使い行えるように

# 検証画像・動画のURL
- 必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/c1b1dc4101c71fc254c65c803f928521

- 入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/771ebeabd01e2c904192d89ceab8dd5d

- ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/5273852ec51edea6bdcabad7e27e2fd9

- ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
- https://gyazo.com/8b1103650fee5ce81d43c9268afc6748


- ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/22f4cfe49950ce20e4d07f3556807a0c

- 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/d54420c4eed79cfacfa286f68a89f821

- 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/02b60996d16deb5c434312c26fa93415

- ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/02b60996d16deb5c434312c26fa93415

- ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/3db9bb34293f7da449c2efa44e49d6b5

 -テスト結果の画像
https://gyazo.com/a0ea62645203825ec4c343418d0050c8
